### PR TITLE
fix bug in formatting (hi_c used, lo_c was needed)

### DIFF
--- a/weather/bot_plugin.py
+++ b/weather/bot_plugin.py
@@ -77,7 +77,7 @@ def format_forecasts(results):
         hi_f = convert_f(hi_c)
         lo_f = convert_f(lo_c)
         txt = fc['text']
-        forecasts += " {} hi: {} C {} F. lo: {} C {} F {}.".format(day, hi_c, hi_f, hi_c, lo_f, txt)
+        forecasts += " {} hi: {} C {} F. lo: {} C {} F {}.".format(day, hi_c, hi_f, lo_c, lo_f, txt)
 
     return forecasts
 


### PR DESCRIPTION
Example of buggy behaviour (emphasis own):

> \<Burrito\> .fc Example
> (Logos) Forecasts and Conditions for Barcelona, Catalonia, ES at 02:00 AM CEST:  Wed hi: **22 C 71 F**. lo: **22 C 68 F** Partly Cloudy. Thu hi: **26 C 78 F**. lo: **26 C 62 F** Scattered Thunderstorms. Fri hi: **24 C 75 F**. lo: **24 C 59 F** Mostly Sunny.
```